### PR TITLE
Delete Yarn Service after stream is completed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-airbyte"
-version = "0.9.0"
+version = "0.9.1"
 description = "Singer tap for Airbyte, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Alex Butler"]

--- a/tap_airbyte/tap.py
+++ b/tap_airbyte/tap.py
@@ -477,7 +477,7 @@ class TapAirbyte(Tap):
         self.logger.debug("File %s created. Streaming file and Waiting for the YARN application to finish.", yarn_service_info['output_file'])
         return [sys.executable, Path(os.path.dirname(os.path.abspath(__file__))) / 'yarn/stream_output.py', "--app_id",
                 yarn_service_info['app_id'], "--yarn_config", orjson.dumps(self.config["yarn_service_config"]),
-                "--service_name", self.config["service_name"],
+                "--service_name", yarn_service_info["service_name"],
                 os.path.join(runtime_tmp_dir, yarn_service_info['output_file'])]
 
 

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -134,13 +134,12 @@ def _get_yarn_service_app_id(yarn_config: YarnConfig, service_uri: str) -> str:
 
 
 def delete_yarn_service(yarn_config: YarnConfig, service_name: str) -> None:
+    """
+    Delete a YARN service (this will force remove libraries and files created by the service)
+    """
     session = _create_session(yarn_config)
     url = f"{yarn_config.get('base_url')}/app/v1/services/{service_name}"
-    response = session.delete(url)
-    if response.status_code != 204:
-        logger.warning(f"Failed to delete Yarn service: {response.json()}")
-    else:
-        logger.info(f"Yarn service deleted: {service_name}")
+    session.delete(url)
 
 
 def is_yarn_app_terminated(yarn_app: YarnApplicationInfo) -> bool:

--- a/tap_airbyte/yarn/stream_output.py
+++ b/tap_airbyte/yarn/stream_output.py
@@ -19,6 +19,7 @@ def main():
         yarn_config=json.loads(args.yarn_config),
         app_id=args.app_id
     )
+    # After finish streaming the file, delete the service to remove the files created by the service
     delete_yarn_service(json.loads(args.yarn_config), args.service_name)
 
 

--- a/tap_airbyte/yarn/stream_output.py
+++ b/tap_airbyte/yarn/stream_output.py
@@ -1,7 +1,7 @@
 import json
 import argparse
 
-from main import stream_file
+from main import stream_file, delete_yarn_service
 
 
 def main():
@@ -10,6 +10,8 @@ def main():
     parser.add_argument("--yarn_config", type=str, required=True, help="Yarn configs.")
     parser.add_argument("--app_id", type=str, required=True,
                         help="Yarn application id to wait for.")
+    parser.add_argument("--service_name", type=str, required=True,
+                        help="Service name that will be used to delete the service after the streaming is done.")
     args = parser.parse_args()
 
     stream_file(
@@ -17,6 +19,7 @@ def main():
         yarn_config=json.loads(args.yarn_config),
         app_id=args.app_id
     )
+    delete_yarn_service(json.loads(args.yarn_config), args.service_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
After the yarn service component is finished, the yarn service is stopped but not deleted keeping the service-created files occupying a few hundreds of MBs on each run.
This PR will force the yarn service to be deleted after the streaming is finished as it will start a new service on every run.