### PR TITLE
[yarn] Wait file be created and non empty before start reading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-airbyte"
-version = "0.9.0"
+version = "0.9.1"
 description = "Singer tap for Airbyte, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Alex Butler"]

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -162,7 +162,7 @@ class TimeoutException(Exception):
     pass
 
 
-def wait_for_file(file_path, timeout=60, interval=1):
+def wait_for_file(file_path, timeout=120, interval=1):
     """
     Waits for a file to be created within a specified timeout.
 
@@ -173,8 +173,8 @@ def wait_for_file(file_path, timeout=60, interval=1):
     """
     start_time = time()
     while time() - start_time < timeout:
-        if os.path.exists(file_path):
-            return # File created
+        if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
+            return # File created and not empty
         sleep(interval)
     raise TimeoutException(f"File not created after {timeout}: {file_path}")
 


### PR DESCRIPTION
If the file takes longer to flush than the YARN application takes to terminate, the application may attempt to read an empty file. Additionally, since catalog operations are faster, the catalog may not be read in time.