### PR TITLE
File Timeout increase

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-airbyte"
-version = "0.9.1"
+version = "0.9.2"
 description = "Singer tap for Airbyte, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Alex Butler"]

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -162,7 +162,7 @@ class TimeoutException(Exception):
     pass
 
 
-def wait_for_file(file_path, timeout=120, interval=1):
+def wait_for_file(file_path, timeout=300, interval=1):
     """
     Waits for a file to be created within a specified timeout.
 


### PR DESCRIPTION
Tests [here](https://github.com/Automattic/nosara/pull/10776#issuecomment-2775105011) failed. As it turns out this is due to file in fuse not being written before the timeout. Not sure why that is, but let's test if a longer timeout will help.

CC @joaopamaral  