### PR TITLE
Use unique service name based on tmp folder name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-airbyte"
-version = "0.9.2"
+version = "0.9.3"
 description = "Singer tap for Airbyte, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Alex Butler"]

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -47,7 +47,7 @@ def run_yarn_service(config: Mapping[str, Any], command: str, runtime_tmp_dir: s
     main_command = command.split()[0].lstrip("--")
     output_file = f'stdout-{command.split()[0].lstrip("--")}'
     output_file_path = os.path.join(runtime_tmp_dir, output_file)
-    service_name = f"{airbyte_image.split('/')[-1]}-{datetime.now().strftime('%Y%m%d%H%M%S')}-{runtime_tmp_dir.split('-')[-1]}"
+    service_name = f"{airbyte_image.split('/')[-1]}-{datetime.now().strftime('%Y%m%d')}-{runtime_tmp_dir.split('-')[-1]}"
     service_config = {
       "name": service_name,
       "version": "1.0",

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -47,7 +47,7 @@ def run_yarn_service(config: Mapping[str, Any], command: str, runtime_tmp_dir: s
     main_command = command.split()[0].lstrip("--")
     output_file = f'stdout-{command.split()[0].lstrip("--")}'
     output_file_path = os.path.join(runtime_tmp_dir, output_file)
-    service_name = f"{airbyte_image.split('/')[-1]}-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    service_name = f"{airbyte_image.split('/')[-1]}-{runtime_tmp_dir.split('/')[-1]}"
     service_config = {
       "name": service_name,
       "version": "1.0",

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -47,7 +47,8 @@ def run_yarn_service(config: Mapping[str, Any], command: str, runtime_tmp_dir: s
     main_command = command.split()[0].lstrip("--")
     output_file = f'stdout-{command.split()[0].lstrip("--")}'
     output_file_path = os.path.join(runtime_tmp_dir, output_file)
-    service_name = f"{airbyte_image.split('/')[-1]}-{datetime.now().strftime('%Y%m%d')}-{runtime_tmp_dir.split('/')[-1].split('-')[-1]}"
+    service_hash = hash(f"{datetime.now().strftime('%Y%m%d%H%M%S')}-{runtime_tmp_dir.split('/')[-1].split('-')[-1]}")
+    service_name = f"{airbyte_image.split('/')[-1]}-{service_hash}"
     service_config = {
       "name": service_name,
       "version": "1.0",

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -47,7 +47,7 @@ def run_yarn_service(config: Mapping[str, Any], command: str, runtime_tmp_dir: s
     main_command = command.split()[0].lstrip("--")
     output_file = f'stdout-{command.split()[0].lstrip("--")}'
     output_file_path = os.path.join(runtime_tmp_dir, output_file)
-    service_name = f"{airbyte_image.split('/')[-1]}-{datetime.now().strftime('%Y%m%d%H%M%S')}-{runtime_tmp_dir.split('/')[-1]}"
+    service_name = f"{airbyte_image.split('/')[-1]}-{datetime.now().strftime('%Y%m%d%H%M%S')}-{runtime_tmp_dir.split('-')[-1]}"
     service_config = {
       "name": service_name,
       "version": "1.0",

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -47,7 +47,7 @@ def run_yarn_service(config: Mapping[str, Any], command: str, runtime_tmp_dir: s
     main_command = command.split()[0].lstrip("--")
     output_file = f'stdout-{command.split()[0].lstrip("--")}'
     output_file_path = os.path.join(runtime_tmp_dir, output_file)
-    service_name = f"{airbyte_image.split('/')[-1]}-{runtime_tmp_dir.split('/')[-1]}"
+    service_name = f"{airbyte_image.split('/')[-1]}-{datetime.now().strftime('%Y%m%d%H%M%S')}-{runtime_tmp_dir.split('/')[-1]}"
     service_config = {
       "name": service_name,
       "version": "1.0",

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from time import sleep, time
 from typing import TypedDict, Mapping, Any
 import logging
+import hashlib
 
 from requests import Session
 from tenacity import retry, stop_after_delay, wait_fixed
@@ -47,8 +48,8 @@ def run_yarn_service(config: Mapping[str, Any], command: str, runtime_tmp_dir: s
     main_command = command.split()[0].lstrip("--")
     output_file = f'stdout-{command.split()[0].lstrip("--")}'
     output_file_path = os.path.join(runtime_tmp_dir, output_file)
-    service_hash = hash(f"{datetime.now().strftime('%Y%m%d%H%M%S')}-{runtime_tmp_dir.split('/')[-1].split('-')[-1]}")
-    service_name = f"{airbyte_image.split('/')[-1]}-{service_hash}"
+    service_hash = hashlib.sha256(f"{datetime.now().strftime('%Y%m%d%H%M%S')}-{runtime_tmp_dir.split('/')[-1].split('-')[-1]}".encode()).hexdigest()
+    service_name = f"{airbyte_image.split('/')[-1]}-{service_hash[:10]}"
     service_config = {
       "name": service_name,
       "version": "1.0",

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -47,7 +47,7 @@ def run_yarn_service(config: Mapping[str, Any], command: str, runtime_tmp_dir: s
     main_command = command.split()[0].lstrip("--")
     output_file = f'stdout-{command.split()[0].lstrip("--")}'
     output_file_path = os.path.join(runtime_tmp_dir, output_file)
-    service_name = f"{airbyte_image.split('/')[-1]}-{datetime.now().strftime('%Y%m%d')}-{runtime_tmp_dir.split('-')[-1]}"
+    service_name = f"{airbyte_image.split('/')[-1]}-{datetime.now().strftime('%Y%m%d')}-{runtime_tmp_dir.split('/')[-1].split('-')[-1]}"
     service_config = {
       "name": service_name,
       "version": "1.0",


### PR DESCRIPTION
If multiple services run the same extractor simultaneously, they might end up using the same service name. This can cause the extraction to fail if a service with that name is already running. As we define a temporary dir for output of each airbyte execution, it will use the temporary dir name in the service name to avoid conflict (as it's unique).