### PR TITLE
Read only full lines from stdout

### DIFF
--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -191,8 +191,13 @@ def read_file(file_path, position) -> int:
             line = file.readline()
             if not line:
                 return position
-            print(line, end='', flush=True)
-            position = file.tell()  # Store current position
+            # Only print if line ends with newline (full line written)
+            if line.endswith('\n'):
+                print(line, end='', flush=True)
+                position = file.tell()
+            else:
+                # Incomplete line — wait until it's finished
+                return position
 
 
 def stream_file(file_path: str, yarn_config: dict, app_id: str) -> None:


### PR DESCRIPTION
We can't control how Yarn writes the file but be can read it more careful way

https://wpcomvip.app.opsgenie.com/alert/detail/e882b1ef-ba63-4141-a809-84e7efac24e1-1754728444983/details