### PR TITLE
Kill YARN app when stream process is terminated before EOF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-airbyte"
-version = "0.10.0"
+version = "0.10.1"
 description = "Singer tap for Airbyte, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Alex Butler"]

--- a/tap_airbyte/tap.py
+++ b/tap_airbyte/tap.py
@@ -574,7 +574,6 @@ class TapAirbyte(Tap):
             )
             try:
                 # Context is held until EOF or exception
-                raise Exception("Simulated crash for testing YARN app kill logic.")
                 yield proc
             finally:
                 if not self.eof_received:

--- a/tap_airbyte/tap.py
+++ b/tap_airbyte/tap.py
@@ -574,6 +574,7 @@ class TapAirbyte(Tap):
             )
             try:
                 # Context is held until EOF or exception
+                raise Exception("Simulated crash for testing YARN app kill logic.")
                 yield proc
             finally:
                 if not self.eof_received:

--- a/tap_airbyte/tap.py
+++ b/tap_airbyte/tap.py
@@ -39,7 +39,7 @@ import virtualenv
 from singer_sdk import Stream, Tap
 from singer_sdk import typing as th
 
-from tap_airbyte.yarn.main import run_yarn_service, wait_for_file
+from tap_airbyte.yarn.main import run_yarn_service, wait_for_file, kill_yarn_app
 
 # Sentinel value for broken pipe
 PIPE_CLOSED = object()
@@ -577,6 +577,11 @@ class TapAirbyte(Tap):
                 yield proc
             finally:
                 if not self.eof_received:
+                    # On YARN, proc is the stream_output.py watcher — the actual YARN app
+                    # keeps running after proc is killed, so we must kill it explicitly.
+                    if self.run_on_yarn and "--app_id" in proc.args:
+                        app_id = proc.args[proc.args.index("--app_id") + 1]
+                        kill_yarn_app(self.config["yarn_service_config"], app_id)
                     proc.kill()
                     self.logger.warning("Airbyte process terminated before EOF message received.")
                 self.logger.debug("Waiting for Airbyte process to terminate.")

--- a/tap_airbyte/yarn/main.py
+++ b/tap_airbyte/yarn/main.py
@@ -149,6 +149,14 @@ def get_yarn_service_application_info(yarn_config: YarnConfig, app_id: str) -> Y
     return response.json().get('app', {})
 
 
+def kill_yarn_app(yarn_config: dict, app_id: str) -> None:
+    session = _create_session(yarn_config)
+    url = f"{yarn_config.get('base_url')}/ws/v1/cluster/apps/{app_id}/state"
+    response = session.put(url, json={"state": "KILLED"})
+    response.raise_for_status()
+    logger.info("Killed YARN application %s", app_id)
+
+
 def is_airbyte_app_running(yarn_config: dict, app_id: str) -> bool:
     app_info = get_yarn_service_application_info(yarn_config, app_id)
     logger.info(app_info)

--- a/tap_airbyte/yarn/stream_output.py
+++ b/tap_airbyte/yarn/stream_output.py
@@ -12,8 +12,6 @@ def main():
                         help="Yarn application id to wait for.")
     args = parser.parse_args()
 
-    raise Exception("Simulated crash for testing YARN app kill logic.")
-
     stream_file(
         file_path=args.file_path,
         yarn_config=json.loads(args.yarn_config),

--- a/tap_airbyte/yarn/stream_output.py
+++ b/tap_airbyte/yarn/stream_output.py
@@ -12,6 +12,8 @@ def main():
                         help="Yarn application id to wait for.")
     args = parser.parse_args()
 
+    raise Exception("Simulated crash for testing YARN app kill logic.")
+
     stream_file(
         file_path=args.file_path,
         yarn_config=json.loads(args.yarn_config),


### PR DESCRIPTION
## Summary

- Adds `kill_yarn_app` function to `yarn/main.py` that sends a `KILLED` state via the YARN RM API
- When running on YARN and the process is terminated before EOF (Airbyte send a ERROR message that will raise an exception in Meltano side), the YARN application is now explicitly killed using the `--app_id` from the `stream_output.py` watcher's args
- Previously, killing `proc` (the watcher script) left the underlying YARN application running indefinitely

Test:
```
Killed YARN application application_1773742130545_48263
Airbyte process terminated before EOF message received.
```

## Test plan

- [ ] Verify that interrupting a YARN-based tap run kills the YARN application
- [ ] Verify normal (EOF-received) runs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)